### PR TITLE
typo in chrome store -- DENY THIS PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ Thanks to Tom Maxwell for the [tutorial and template code](https://9to5google.co
 Enjoy!
 
 -CBL
+ 


### PR DESCRIPTION
**DENY THIS PR**

Not a huge deal, just wanted to let you know that the Chrome store listing for this extension has a typo.

Currently, the SPECIAL THANKS section on the Chrome store reads:

SPECIAL THANKS:
Twitter user @mims (Christopher Mims) for the suggestion to make a "browser extension that replaces "multiple copies of a giant excel spreadsheet" with "mulitple copies of a giant Excel spreadsheet." For example, "multiple copies of a giant excel spreadsheet to revolutionize journalism.

and I think you meant it to say:

SPECIAL THANKS:
Twitter user @mims (Christopher Mims) for the suggestion to make a "browser extension that replaces "blockchain" with "multiple copies of a giant Excel spreadsheet." For example, "multiple copies of a giant excel spreadsheet to revolutionize journalism.

as it does in the README.md file here on the repo. Not a huge deal, it just might be confusing for people checking it out on the Chrome store.

P.S.: This extension is hilarious. Thank you for making it!